### PR TITLE
github: bump MSRV to 1.73.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.70.0 # MSRV
+          - 1.73.0 # MSRV
         runs_on:
           - ubuntu-latest
           - windows-latest
@@ -43,7 +43,7 @@ jobs:
             rust: beta
           - runs_on: ubuntu-latest
             feature: net-tokio,socket2
-            rust: 1.70.0 # MSRV
+            rust: 1.73.0 # MSRV
     env:
       RUSTFLAGS: --deny warnings
     steps:


### PR DESCRIPTION
This is done due to an indirect `bstr v1.11.0` dependency needed by
`tera`:

error: package `bstr v1.11.0` cannot be built because it requires rustc 1.73 or newer, while the currently active rustc version is 1.70.0
