### PR TITLE
rsdns: fix `clippy::needless-lifetimes` warnings

### DIFF
--- a/templates/async_client_impl.rs
+++ b/templates/async_client_impl.rs
@@ -122,7 +122,7 @@ struct ClientCtx<'a, 'b, 'c, 'd> {
     buf: &'d mut [u8],
 }
 
-impl<'a, 'b, 'c, 'd> ClientCtx<'a, 'b, 'c, 'd> {
+impl ClientCtx<'_, '_, '_, '_> {
     async fn query_raw(&mut self) -> Result<usize> {
         let query_lifetime = self.config.query_lifetime();
 


### PR DESCRIPTION
Appeared since rustc v1.84.0-beta.2
