### PR TITLE
Fix fuzz job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,8 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - name: install llvm-12
-        run: sudo apt install -y llvm-12
+      - name: install llvm-18
+        run: sudo apt install -y llvm-18
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION

Since GH runners have moved to Ubuntu 24.04.1 llvm-12 package is not
available anymore and the job fails.
