### PR TITLE
Fix CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,8 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - name: install llvm-12
-        run: sudo apt install -y llvm-12
+      - name: install llvm-18
+        run: sudo apt install -y llvm-18
 
       - uses: actions/checkout@v4
 

--- a/src/message/flags.rs
+++ b/src/message/flags.rs
@@ -59,7 +59,7 @@ impl Flags {
     #[cfg(test)]
     pub(crate) fn set_opcode(&mut self, opcode: OpCode) -> &mut Self {
         let mask = 0b0111_1000_0000_0000;
-        self.bits = (self.bits & !mask) | (opcode.value() as u16) << 11;
+        self.bits = (self.bits & !mask) | ((opcode.value() as u16) << 11);
         self
     }
 

--- a/src/message/reader/questions.rs
+++ b/src/message/reader/questions.rs
@@ -1,7 +1,7 @@
 use crate::{
     bytes::{Cursor, Reader},
     message::Question,
-    Error, Result,
+    Result,
 };
 
 /// An iterator over the questions section of a message.
@@ -61,7 +61,7 @@ impl<'a> Questions<'a> {
         } else {
             self.err = true;
         }
-        Some(res.map_err(Error::from))
+        Some(res)
     }
 }
 

--- a/src/records/opt.rs
+++ b/src/records/opt.rs
@@ -27,7 +27,7 @@ impl Opt {
         }
 
         fn ttl(&self) -> u32 {
-            (self.rcode_extension as u32) << 24 | (self.version as u32) << 16 | self.flags as u32
+            ((self.rcode_extension as u32) << 24) | ((self.version as u32) << 16) | self.flags as u32
         }
     }
 


### PR DESCRIPTION
Since GH runners have moved to Ubuntu 24.04.1 llvm-12 package is not
available anymore and the job fails.

Replace llvm-12 with llvm-18.
Fix clippy warnings that appear since release of v1.85.0 beta versions.
