### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/bytes/cursor.rs
+++ b/src/bytes/cursor.rs
@@ -86,11 +86,7 @@ impl<'s, 'a: 's> Cursor<'a> {
 
     pub fn len(&self) -> usize {
         let capacity = self.capacity();
-        if self.pos < capacity {
-            capacity - self.pos
-        } else {
-            0
-        }
+        capacity.saturating_sub(self.pos)
     }
 
     #[inline]

--- a/src/bytes/wcursor.rs
+++ b/src/bytes/wcursor.rs
@@ -27,11 +27,7 @@ impl<'a> WCursor<'a> {
     #[inline]
     pub fn len(&self) -> usize {
         let capacity = self.capacity();
-        if self.pos < capacity {
-            capacity - self.pos
-        } else {
-            0
-        }
+        capacity.saturating_sub(self.pos)
     }
 
     #[inline]

--- a/src/message/rcode.rs
+++ b/src/message/rcode.rs
@@ -431,10 +431,7 @@ mod test {
 
         for i in 0..=u8::MAX {
             let rcode = RCode::from(i as u16);
-            assert_eq!(
-                rcode.is_defined(),
-                RCode::VALUES.iter().any(|e| *e == rcode)
-            );
+            assert_eq!(rcode.is_defined(), RCode::VALUES.contains(&rcode));
         }
     }
 }


### PR DESCRIPTION

These appeared since `rustc v1.87.0-beta.2`.