### PR TITLE
cargo: upgrade to `rand 0.9.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [".git*", "Makefile.toml"]
 [dependencies]
 thiserror = "1.0.26"
 arrayvec = "0.7.1"
-rand = "0.8.4"
+rand = "0.9.1"
 cfg-if = "1.0.0"
 tokio = { version = "1", optional = true, default-features = false, features = [
     "rt",

--- a/src/message/header.rs
+++ b/src/message/header.rs
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn test_serialization() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let flags = *Flags::new()
             .set_message_type(rand::random::<bool>().into())


### PR DESCRIPTION
Was using 0.8.x previously.
