### PR TITLE
reader: fix `mismatched_lifetime_syntaxes` clippy warning

### DIFF
--- a/src/message/reader/message_iterator.rs
+++ b/src/message/reader/message_iterator.rs
@@ -87,7 +87,7 @@ pub struct MessageIterator<'a> {
 impl MessageIterator<'_> {
     /// Creates a reader for a message contained in `buf`.
     #[inline]
-    pub fn new(buf: &[u8]) -> Result<MessageIterator> {
+    pub fn new(buf: &[u8]) -> Result<MessageIterator<'_>> {
         let mut cursor = Cursor::new(buf);
         let header: Header = cursor.read()?;
         let mut mi = MessageIterator {
@@ -120,7 +120,7 @@ impl MessageIterator<'_> {
 
     /// Returns an iterator over the questions section of the message.
     #[inline]
-    pub fn questions(&self) -> Questions {
+    pub fn questions(&self) -> Questions<'_> {
         Questions::new(
             Cursor::with_pos(self.buf, HEADER_LENGTH),
             self.header.qd_count,
@@ -129,7 +129,7 @@ impl MessageIterator<'_> {
 
     /// Returns an iterator over the resource record sections of the message.
     #[inline]
-    pub fn records(&self) -> Records {
+    pub fn records(&self) -> Records<'_> {
         Records::new(
             Cursor::with_pos(self.buf, self.offsets[RecordsSection::Answer as usize]),
             &self.header,


### PR DESCRIPTION
This commit fixes clippy warning [1] that appeared since 1.89.0-beta.1

[1]

warning: lifetime flowing from input to output with different syntax can be confusing
  --> src/message/reader/message_iterator.rs:90:21
   |
90 |     pub fn new(buf: &[u8]) -> Result<MessageIterator> {
   |                     ^^^^^            --------------- the lifetime gets resolved as `'_`
   |                     |
   |                     this lifetime flows to the output
   |
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
90 |     pub fn new(buf: &[u8]) -> Result<MessageIterator<'_>> {
   |                                                     ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/message/reader/message_iterator.rs:123:22
    |
123 |     pub fn questions(&self) -> Questions {
    |                      ^^^^^     --------- the lifetime gets resolved as `'_`
    |                      |
    |                      this lifetime flows to the output
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
123 |     pub fn questions(&self) -> Questions<'_> {
    |                                         ++++

warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/message/reader/message_iterator.rs:132:20
    |
132 |     pub fn records(&self) -> Records {
    |                    ^^^^^     ------- the lifetime gets resolved as `'_`
    |                    |
    |                    this lifetime flows to the output
    |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
132 |     pub fn records(&self) -> Records<'_> {
    |                                     ++++

warning: `rsdns` (lib) generated 3 warnings
