### PR TITLE
templates: replace `tera` with `zyn`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.85.0 # MSRV
+          - 1.88.0 # MSRV
         runs_on:
           - ubuntu-latest
           - windows-latest
@@ -43,7 +43,7 @@ jobs:
             rust: beta
           - runs_on: ubuntu-latest
             feature: net-tokio,socket2
-            rust: 1.85.0 # MSRV
+            rust: 1.88.0 # MSRV
     env:
       RUSTFLAGS: --deny warnings
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["dns", "dig", "async", "resolver"]
 categories = ["asynchronous", "network-programming", "parser-implementations"]
 repository = "https://github.com/r-bk/rsdns"
 exclude = [".git*", "Makefile.toml"]
-rust-version = "1.85"
+rust-version = "1.88"
 
 [dependencies]
 thiserror = "2.0.12"
@@ -38,7 +38,8 @@ net-smol = ["dep:smol", "dep:smol-timeout"]
 socket2 = ["dep:socket2"]
 
 [build-dependencies]
-tera = "1.18.1"
+zyn = "0.5.4"
+prettyplease = "0.2"
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.88"
 [dependencies]
 thiserror = "2.0.12"
 arrayvec = "0.7.1"
-rand = "0.9.1"
+rand = "0.10.1"
 cfg-if = "1.0.0"
 tokio = { version = "1", optional = true, default-features = false, features = [
     "rt",

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,10 @@
-use std::process::Command;
-use tera::{Context, Tera};
+use zyn::TokenStream;
+
+#[path = "templates/async_client_impl.rs"]
+mod async_client_impl_template;
+
+#[path = "templates/client.rs"]
+mod client_template;
 
 const NET_CRATES: &[&str] = &["tokio", "async-std", "smol", "std"];
 
@@ -16,51 +21,35 @@ fn need_crate(crate_name: &str) -> bool {
     std::env::var_os(env_var).is_some()
 }
 
-fn format_file(path: &std::path::Path) -> bool {
-    let path_str = path.to_str().unwrap();
-    Command::new("rustfmt")
-        .args(["--edition", "2021"])
-        .arg(path_str)
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
-fn write_file(tera: &Tera, context: &Context, file_name: &str, crate_name: &str) {
+fn write_file(tokens: TokenStream, file_name: &str, crate_name: &str) {
     let out_dir = std::env::var_os("OUT_DIR").unwrap();
-    let template_name = format!("{file_name}.rs");
-    let file_data = tera
-        .render(&template_name, context)
-        .expect("failed to render template");
     let dest_file_name = format!("{}_{}.rs", file_name, dashes_to_underscores(crate_name));
     let dest_file_path = std::path::Path::new(&out_dir).join(dest_file_name);
-    std::fs::write(&dest_file_path, file_data).expect("failed to write file");
-    format_file(&dest_file_path);
+    let syntax_tree: zyn::syn::File =
+        zyn::syn::parse2(tokens).expect("failed to parse generated tokens");
+    let pretty = prettyplease::unparse(&syntax_tree);
+    std::fs::write(&dest_file_path, pretty).expect("failed to write file");
 }
 
-fn write_clients(tera: &Tera) {
+fn write_clients() {
     for crate_name in NET_CRATES {
         if !need_crate(crate_name) {
             continue;
         }
+        let is_async = *crate_name != "std";
 
-        let mut context = Context::new();
-        context.insert("feature", &format!("net-{crate_name}"));
-        context.insert("crate_name", crate_name);
-        context.insert("crate_module_name", &dashes_to_underscores(crate_name));
-        context.insert(
-            "async",
-            if *crate_name != "std" {
-                "true"
-            } else {
-                "false"
-            },
+        write_file(
+            client_template::render(crate_name, is_async),
+            "client",
+            crate_name,
         );
 
-        write_file(tera, &context, "client", crate_name);
-
-        if *crate_name != "std" {
-            write_file(tera, &context, "async_client_impl", crate_name);
+        if is_async {
+            write_file(
+                async_client_impl_template::render(crate_name),
+                "async_client_impl",
+                crate_name,
+            );
         }
     }
 
@@ -69,12 +58,5 @@ fn write_clients(tera: &Tera) {
 }
 
 fn main() {
-    let tera = match Tera::new("templates/*.rs") {
-        Ok(t) => t,
-        Err(e) => {
-            panic!("Tera parsing error(s): {e}");
-        }
-    };
-
-    write_clients(&tera);
+    write_clients();
 }

--- a/src/clients/std/client_impl.rs
+++ b/src/clients/std/client_impl.rs
@@ -199,13 +199,12 @@ impl ClientCtx<'_, '_, '_, '_> {
                 continue;
             }
 
-            if let Ok(question) = mr.the_question() {
-                if question.qtype == self.qtype
-                    && question.qclass == self.qclass
-                    && question.qname == self.qname
-                {
-                    return Ok((size, header.flags));
-                }
+            if let Ok(question) = mr.the_question()
+                && question.qtype == self.qtype
+                && question.qclass == self.qclass
+                && question.qname == self.qname
+            {
+                return Ok((size, header.flags));
             }
         }
     }

--- a/src/records/record_set.rs
+++ b/src/records/record_set.rs
@@ -111,12 +111,14 @@ impl<D: RData> RecordSet<D> {
 
         #[allow(clippy::manual_flatten)]
         for o in headers.iter_mut() {
-            if let Some(h) = o {
-                if h.name().eq(name)? && h.rtype() == D::RTYPE && h.rclass() == rclass {
-                    rrset.ttl = rrset.ttl.min(h.ttl());
-                    rrset.rdata.push(mr.record_data_at::<D>(h.marker())?);
-                    o.take();
-                }
+            if let Some(h) = o
+                && h.name().eq(name)?
+                && h.rtype() == D::RTYPE
+                && h.rclass() == rclass
+            {
+                rrset.ttl = rrset.ttl.min(h.ttl());
+                rrset.rdata.push(mr.record_data_at::<D>(h.marker())?);
+                o.take();
             }
         }
 
@@ -136,12 +138,14 @@ impl<D: RData> RecordSet<D> {
     ) -> Result<Option<NameRef<'a>>> {
         #[allow(clippy::manual_flatten)]
         for o in headers.iter_mut() {
-            if let Some(h) = o {
-                if h.name().eq(name)? && h.rtype() == Type::CNAME && h.rclass() == rclass {
-                    let n = mr.name_ref_at(h.marker());
-                    o.take();
-                    return Ok(Some(n));
-                }
+            if let Some(h) = o
+                && h.name().eq(name)?
+                && h.rtype() == Type::CNAME
+                && h.rclass() == rclass
+            {
+                let n = mr.name_ref_at(h.marker());
+                o.take();
+                return Ok(Some(n));
             }
         }
         Ok(None)

--- a/templates/async_client_impl.rs
+++ b/templates/async_client_impl.rs
@@ -224,12 +224,12 @@ pub fn render(crate_name: &str) -> TokenStream {
                         continue;
                     }
 
-                    if let Ok(question) = mr.the_question() {
-                        if question.qtype == self.qtype
-                            && question.qclass == self.qclass
-                            && question.qname == self.qname {
-                            return Ok((size, header.flags));
-                        }
+                    if let Ok(question) = mr.the_question()
+                        && question.qtype == self.qtype
+                        && question.qclass == self.qclass
+                        && question.qname == self.qname
+                    {
+                        return Ok((size, header.flags));
                     }
                 }
             }

--- a/templates/async_client_impl.rs
+++ b/templates/async_client_impl.rs
@@ -1,384 +1,373 @@
-use crate::{
-    clients::config::{ProtocolStrategy, Recursion, ClientConfig, EDns},
-    constants::DNS_MESSAGE_BUFFER_MIN_LENGTH,
-    message::{reader::MessageReader, Flags, QueryWriter},
-    records::{data::RData, Class, RecordSet, Opt, Type},
-    Error, Result,
-};
+use zyn::TokenStream;
 
-{% if crate_name == "tokio" %}
-
-    use tokio::{
-        net::{TcpStream, UdpSocket},
-        io::{AsyncReadExt, AsyncWriteExt},
-        time::timeout
-    };
-
-    #[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))]
-    use std::os::unix::io::{IntoRawFd, FromRawFd};
-
-    #[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))]
-    use tokio::net::TcpSocket;
-
-{% elif crate_name == "async-std" %}
-
-    use async_std::{
-        future::timeout,
-        net::{TcpStream, UdpSocket},
-        io::prelude::{ReadExt, WriteExt}
-    };
-
-{% elif crate_name == "smol" %}
-
-    use smol::{
-        net::{TcpStream, UdpSocket},
-        io::{AsyncReadExt, AsyncWriteExt},
-    };
-    use smol_timeout::TimeoutExt;
-
-{% endif %}
-
-const QUERY_BUFFER_SIZE: usize = 288;
-type MsgBuf = arrayvec::ArrayVec<u8, QUERY_BUFFER_SIZE>;
-
-pub struct ClientImpl {
-    config: ClientConfig,
-    sock: UdpSocket,
-    buf: Vec<u8>,
-}
-
-impl ClientImpl {
-    pub async fn new(config: ClientConfig) -> Result<Self> {
-        let sock = udp_socket(&config).await?;
-        let buf = match config.buffer_size() {
-            0 => Vec::new(),
-            bs => Vec::with_capacity(bs),
+pub fn render(crate_name: &str) -> TokenStream {
+    zyn::zyn! {
+        use crate::{
+            clients::config::{ProtocolStrategy, Recursion, ClientConfig, EDns},
+            constants::DNS_MESSAGE_BUFFER_MIN_LENGTH,
+            message::{reader::MessageReader, Flags, QueryWriter},
+            records::{data::RData, Class, RecordSet, Opt, Type},
+            Error, Result,
         };
-        Ok(Self { config, sock, buf })
-    }
 
-    pub fn config(&self) -> &ClientConfig {
-        &self.config
-    }
+        @if (crate_name == "tokio") {
+            use tokio::{
+                net::{TcpStream, UdpSocket},
+                io::{AsyncReadExt, AsyncWriteExt},
+                time::timeout
+            };
 
-    pub async fn query_raw(&self, qname: &str, qtype: Type, qclass: Class, buf: &mut [u8]) -> Result<usize> {
-        if buf.len() < DNS_MESSAGE_BUFFER_MIN_LENGTH {
-            return Err(Error::BufferTooShort(DNS_MESSAGE_BUFFER_MIN_LENGTH));
-        }
-        let mut ctx = ClientCtx {
-            qname,
-            qtype,
-            qclass,
-            sock: &self.sock,
-            config: &self.config,
-            msg_id: 0,
-            msg: MsgBuf::default(),
-            buf
-        };
-        ctx.prepare_message()?;
-        ctx.query_raw().await
-    }
+            #[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))]
+            use std::os::unix::io::{IntoRawFd, FromRawFd};
 
-    #[allow(clippy::await_holding_refcell_ref)]
-    pub async fn query_rrset<D: RData>(&mut self, qname: &str, qclass: Class) -> Result<RecordSet<D>> {
-        if self.config.buffer_size() == 0 {
-            return Err(Error::BadParam("non-zero buffer_size is required"));
+            #[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))]
+            use tokio::net::TcpSocket;
         }
-        if !qclass.is_data_class() {
-            return Err(Error::UnsupportedClass(qclass));
+        @else if (crate_name == "async-std") {
+            use async_std::{
+                future::timeout,
+                net::{TcpStream, UdpSocket},
+                io::prelude::{ReadExt, WriteExt}
+            };
         }
-        let mut buf = unsafe { self.take_buf() };
-        let response_len = match self.query_raw(qname, D::RTYPE, qclass, &mut buf).await {
-            Ok(v) => v,
-            Err(e) => {
+        @else if (crate_name == "smol") {
+            use smol::{
+                net::{TcpStream, UdpSocket},
+                io::{AsyncReadExt, AsyncWriteExt},
+            };
+            use smol_timeout::TimeoutExt;
+        }
+
+        const QUERY_BUFFER_SIZE: usize = 288;
+        type MsgBuf = arrayvec::ArrayVec<u8, QUERY_BUFFER_SIZE>;
+
+        pub struct ClientImpl {
+            config: ClientConfig,
+            sock: UdpSocket,
+            buf: Vec<u8>,
+        }
+
+        impl ClientImpl {
+            pub async fn new(config: ClientConfig) -> Result<Self> {
+                let sock = udp_socket(&config).await?;
+                let buf = match config.buffer_size() {
+                    0 => Vec::new(),
+                    bs => Vec::with_capacity(bs),
+                };
+                Ok(Self { config, sock, buf })
+            }
+
+            pub fn config(&self) -> &ClientConfig {
+                &self.config
+            }
+
+            pub async fn query_raw(&self, qname: &str, qtype: Type, qclass: Class, buf: &mut [u8]) -> Result<usize> {
+                if buf.len() < DNS_MESSAGE_BUFFER_MIN_LENGTH {
+                    return Err(Error::BufferTooShort(DNS_MESSAGE_BUFFER_MIN_LENGTH));
+                }
+                let mut ctx = ClientCtx {
+                    qname,
+                    qtype,
+                    qclass,
+                    sock: &self.sock,
+                    config: &self.config,
+                    msg_id: 0,
+                    msg: MsgBuf::default(),
+                    buf
+                };
+                ctx.prepare_message()?;
+                ctx.query_raw().await
+            }
+
+            #[allow(clippy::await_holding_refcell_ref)]
+            pub async fn query_rrset<D: RData>(&mut self, qname: &str, qclass: Class) -> Result<RecordSet<D>> {
+                if self.config.buffer_size() == 0 {
+                    return Err(Error::BadParam("non-zero buffer_size is required"));
+                }
+                if !qclass.is_data_class() {
+                    return Err(Error::UnsupportedClass(qclass));
+                }
+                let mut buf = unsafe { self.take_buf() };
+                let response_len = match self.query_raw(qname, D::RTYPE, qclass, &mut buf).await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        std::mem::swap(&mut self.buf, &mut buf);
+                        return Err(e);
+                    }
+                };
+                unsafe {
+                    buf.set_len(response_len);
+                }
+                let result = RecordSet::from_msg(&buf);
                 std::mem::swap(&mut self.buf, &mut buf);
-                return Err(e);
+                result
             }
-        };
-        unsafe {
-            buf.set_len(response_len);
-        }
-        let result = RecordSet::from_msg(&buf);
-        std::mem::swap(&mut self.buf, &mut buf);
-        result
-    }
 
-    unsafe fn take_buf(&mut self) -> Vec<u8> {
-        let mut buf = std::mem::take(&mut self.buf);
-        if buf.capacity() < self.config.buffer_size() {
-            buf.reserve(self.config.buffer_size() - buf.capacity());
-        }
-        unsafe {
-            buf.set_len(self.config.buffer_size());
-        }
-        buf
-    }
-}
-
-struct ClientCtx<'a, 'b, 'c, 'd> {
-    qname: &'a str,
-    qtype: Type,
-    qclass: Class,
-    sock: &'b UdpSocket,
-    config: &'c ClientConfig,
-    msg_id: u16,
-    msg: MsgBuf,
-    buf: &'d mut [u8],
-}
-
-impl ClientCtx<'_, '_, '_, '_> {
-    async fn query_raw(&mut self) -> Result<usize> {
-        let query_lifetime = self.config.query_lifetime();
-
-        let future = self.query_raw_impl();
-
-        {% if crate_name == "tokio" or crate_name == "async-std" %}
-
-        match timeout(query_lifetime, future).await {
-            Ok(res) => res,
-            Err(_) => Err(Error::Timeout),
-        }
-
-        {% elif crate_name == "smol" %}
-
-        match future.timeout(query_lifetime).await {
-            Some(res) => res,
-            None => Err(Error::Timeout),
-        }
-
-        {% endif %}
-    }
-
-    async fn query_raw_impl(&mut self) -> Result<usize> {
-        if self.udp_first() {
-            let (size, flags) = self.udp_exchange_loop().await?;
-
-            if flags.truncated() && self.tcp_allowed() {
-                self.tcp_exchange().await
-            } else {
-                Ok(size)
+            unsafe fn take_buf(&mut self) -> Vec<u8> {
+                let mut buf = std::mem::take(&mut self.buf);
+                if buf.capacity() < self.config.buffer_size() {
+                    buf.reserve(self.config.buffer_size() - buf.capacity());
+                }
+                unsafe {
+                    buf.set_len(self.config.buffer_size());
+                }
+                buf
             }
-        } else {
-            self.tcp_exchange().await
-        }
-    }
-
-    async fn tcp_exchange(&mut self) -> Result<usize> {
-        let mut sock = tcp_socket(self.config).await?;
-
-        sock.write_all(&self.msg).await?;
-
-        let mut response_size_buf = [0u8; 2];
-        sock.read_exact(&mut response_size_buf).await?;
-
-        let response_size = u16::from_be_bytes(response_size_buf) as usize;
-
-        if response_size > self.buf.len() {
-            return Err(Error::BufferTooShort(response_size));
         }
 
-        sock.read_exact(&mut self.buf[..response_size]).await?;
+        struct ClientCtx<'a, 'b, 'c, 'd> {
+            qname: &'a str,
+            qtype: Type,
+            qclass: Class,
+            sock: &'b UdpSocket,
+            config: &'c ClientConfig,
+            msg_id: u16,
+            msg: MsgBuf,
+            buf: &'d mut [u8],
+        }
 
-        Ok(response_size)
-    }
+        impl ClientCtx<'_, '_, '_, '_> {
+            async fn query_raw(&mut self) -> Result<usize> {
+                let query_lifetime = self.config.query_lifetime();
 
-    async fn udp_exchange_loop(&mut self) -> Result<(usize, Flags)> {
-        loop {
-            self.sock.send(&self.msg[2..]).await?;
+                let future = self.query_raw_impl();
 
-            let query_timeout = self.config.query_timeout();
+                @if (crate_name == "tokio" || crate_name == "async-std") {
+                    match timeout(query_lifetime, future).await {
+                        Ok(res) => res,
+                        Err(_) => Err(Error::Timeout),
+                    }
+                }
+                @else if (crate_name == "smol") {
+                    match future.timeout(query_lifetime).await {
+                        Some(res) => res,
+                        None => Err(Error::Timeout),
+                    }
+                }
+            }
 
-            let future = self.udp_receive_loop();
+            async fn query_raw_impl(&mut self) -> Result<usize> {
+                if self.udp_first() {
+                    let (size, flags) = self.udp_exchange_loop().await?;
 
-            if let Some(query_timeout) = query_timeout {
-                {% if crate_name == "tokio" or crate_name == "async-std" %}
+                    if flags.truncated() && self.tcp_allowed() {
+                        self.tcp_exchange().await
+                    } else {
+                        Ok(size)
+                    }
+                } else {
+                    self.tcp_exchange().await
+                }
+            }
 
-                match timeout(query_timeout, future).await {
-                    Ok(res) => return res,
-                    Err(_) => continue,
+            async fn tcp_exchange(&mut self) -> Result<usize> {
+                let mut sock = tcp_socket(self.config).await?;
+
+                sock.write_all(&self.msg).await?;
+
+                let mut response_size_buf = [0u8; 2];
+                sock.read_exact(&mut response_size_buf).await?;
+
+                let response_size = u16::from_be_bytes(response_size_buf) as usize;
+
+                if response_size > self.buf.len() {
+                    return Err(Error::BufferTooShort(response_size));
+                }
+
+                sock.read_exact(&mut self.buf[..response_size]).await?;
+
+                Ok(response_size)
+            }
+
+            async fn udp_exchange_loop(&mut self) -> Result<(usize, Flags)> {
+                loop {
+                    self.sock.send(&self.msg[2..]).await?;
+
+                    let query_timeout = self.config.query_timeout();
+
+                    let future = self.udp_receive_loop();
+
+                    if let Some(query_timeout) = query_timeout {
+                        @if (crate_name == "tokio" || crate_name == "async-std") {
+                            match timeout(query_timeout, future).await {
+                                Ok(res) => return res,
+                                Err(_) => continue,
+                            };
+                        }
+                        @else if (crate_name == "smol") {
+                            match future.timeout(query_timeout).await {
+                                Some(res) => return res,
+                                None => continue,
+                            };
+                        }
+                    } else {
+                        return future.await;
+                    }
+                }
+            }
+
+            async fn udp_receive_loop(&mut self) -> Result<(usize, Flags)> {
+                loop {
+                    let size = self.sock.recv(self.buf).await?;
+
+                    let response = &self.buf[..size];
+                    let mut mr = match MessageReader::new(response) {
+                        Ok(mr) => mr,
+                        Err(_) => continue,
+                    };
+                    let header = match mr.header() {
+                        Ok(h) => h,
+                        Err(_) => continue,
+                    };
+
+                    if header.id != self.msg_id {
+                        continue;
+                    }
+
+                    if let Ok(question) = mr.the_question() {
+                        if question.qtype == self.qtype
+                            && question.qclass == self.qclass
+                            && question.qname == self.qname {
+                            return Ok((size, header.flags));
+                        }
+                    }
+                }
+            }
+
+            fn prepare_message(&mut self) -> Result<()> {
+                let opt = match self.config.edns_ {
+                    EDns::On {
+                        version,
+                        udp_payload_size
+                    } => {
+                        let ups = (udp_payload_size as usize).min(self.buf.len());
+                        Some(Opt::new(version, ups as u16))
+                    },
+                    EDns::Off => None,
                 };
+                unsafe { self.msg.set_len(self.msg.capacity()); }
+                let mut qw = QueryWriter::new(&mut self.msg);
+                self.msg_id = qw.message_id();
+                let msg_len = qw.write(self.qname, self.qtype, self.qclass,
+                                       self.config.recursion_ == Recursion::On, opt)?;
+                unsafe { self.msg.set_len(msg_len); }
+                Ok(())
+            }
 
-                {% elif crate_name == "smol" %}
+            #[inline]
+            fn udp_first(&self) -> bool {
+                match self.config.protocol_strategy_ {
+                    ProtocolStrategy::Udp | ProtocolStrategy::NoTcp => true,
+                    ProtocolStrategy::Tcp => false,
+                }
+            }
 
-                match future.timeout(query_timeout).await {
-                    Some(res) => return res,
-                    None => continue,
-                };
-
-                {% endif %}
-            } else {
-                return future.await;
+            #[inline]
+            fn tcp_allowed(&self) -> bool {
+                self.config.protocol_strategy_ != ProtocolStrategy::NoTcp
             }
         }
-    }
 
-    async fn udp_receive_loop(&mut self) -> Result<(usize, Flags)> {
-        loop {
-            let size = self.sock.recv(self.buf).await?;
+        @if (crate_name == "tokio") {
+            #[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))]
+            async fn udp_socket2(config: &ClientConfig) -> Result<UdpSocket> {
+                if config.interface_.is_empty() {
+                    return udp_socket_simple(config).await;
+                }
 
-            let response = &self.buf[..size];
-            let mut mr = match MessageReader::new(response) {
-                Ok(mr) => mr,
-                Err(_) => continue,
-            };
-            let header = match mr.header() {
-                Ok(h) => h,
-                Err(_) => continue,
-            };
+                let mut interface = config.interface_;
+                interface.try_push(char::default()).ok();
 
-            if header.id != self.msg_id {
-                continue;
+                let sock = socket2::Socket::new(
+                    socket2::Domain::for_address(config.nameserver_),
+                    socket2::Type::DGRAM.nonblocking().cloexec(),
+                    Some(socket2::Protocol::UDP)
+                )?;
+
+                sock.bind_device(Some(interface.as_bytes()))?;
+
+                let sockaddr = socket2::SockAddr::from(config.bind_addr_);
+                sock.bind(&sockaddr)?;
+
+                let sockaddr = socket2::SockAddr::from(config.nameserver_);
+                sock.connect(&sockaddr)?;
+
+                let std_sock = unsafe { std::net::UdpSocket::from_raw_fd(sock.into_raw_fd()) };
+
+                Ok(UdpSocket::from_std(std_sock)?)
             }
 
-            if let Ok(question) = mr.the_question() {
-                if question.qtype == self.qtype
-                    && question.qclass == self.qclass
-                    && question.qname == self.qname {
-                    return Ok((size, header.flags));
+            #[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))]
+            async fn tcp_socket2(config: &ClientConfig) -> Result<TcpStream> {
+                if config.interface_.is_empty() {
+                    return tcp_socket_simple(config).await;
+                }
+
+                let mut interface = config.interface_;
+                interface.try_push(char::default()).ok();
+
+                let sock = socket2::Socket::new(
+                    socket2::Domain::for_address(config.nameserver_),
+                    socket2::Type::STREAM.nonblocking().cloexec(),
+                    Some(socket2::Protocol::TCP)
+                )?;
+
+                sock.bind_device(Some(interface.as_bytes()))?;
+                sock.set_tcp_nodelay(true)?;
+
+                let tcp_socket = unsafe { TcpSocket::from_raw_fd(sock.into_raw_fd()) };
+
+                Ok(tcp_socket.connect(config.nameserver_).await?)
+            }
+        }
+
+        #[inline(always)]
+        async fn udp_socket_simple(config: &ClientConfig) -> Result<UdpSocket> {
+            let sock = UdpSocket::bind(config.bind_addr_).await?;
+            sock.connect(config.nameserver_).await?;
+            Ok(sock)
+        }
+
+        #[inline(always)]
+        async fn tcp_socket_simple(config: &ClientConfig) -> Result<TcpStream> {
+            let sock = TcpStream::connect(config.nameserver_).await?;
+            sock.set_nodelay(true)?;
+            Ok(sock)
+        }
+
+        #[inline(always)]
+        async fn udp_socket(config: &ClientConfig) -> Result<UdpSocket> {
+            @if (crate_name != "tokio") {
+                udp_socket_simple(config).await
+            }
+            @else {
+                cfg_if::cfg_if! {
+                    if #[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))] {
+                        udp_socket2(config).await
+                    }
+                    else {
+                        udp_socket_simple(config).await
+                    }
+                }
+            }
+        }
+
+        #[inline(always)]
+        async fn tcp_socket(config: &ClientConfig) -> Result<TcpStream> {
+            @if (crate_name != "tokio") {
+                tcp_socket_simple(config).await
+            }
+            @else {
+                cfg_if::cfg_if! {
+                    if #[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))] {
+                        tcp_socket2(config).await
+                    }
+                    else {
+                        tcp_socket_simple(config).await
+                    }
                 }
             }
         }
     }
-
-    fn prepare_message(&mut self) -> Result<()> {
-        let opt = match self.config.edns_ {
-            EDns::On {
-                version,
-                udp_payload_size
-            } => {
-                let ups = (udp_payload_size as usize).min(self.buf.len());
-                Some(Opt::new(version, ups as u16))
-            },
-            EDns::Off => None,
-        };
-        unsafe { self.msg.set_len(self.msg.capacity()); }
-        let mut qw = QueryWriter::new(&mut self.msg);
-        self.msg_id = qw.message_id();
-        let msg_len = qw.write(self.qname, self.qtype, self.qclass,
-                               self.config.recursion_ == Recursion::On, opt)?;
-        unsafe { self.msg.set_len(msg_len); }
-        Ok(())
-    }
-
-    #[inline]
-    fn udp_first(&self) -> bool {
-        match self.config.protocol_strategy_ {
-            ProtocolStrategy::Udp | ProtocolStrategy::NoTcp => true,
-            ProtocolStrategy::Tcp => false,
-        }
-    }
-
-    #[inline]
-    fn tcp_allowed(&self) -> bool {
-        self.config.protocol_strategy_ != ProtocolStrategy::NoTcp
-    }
-}
-
-{% if crate_name == "tokio" %}
-
-#[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))]
-async fn udp_socket2(config: &ClientConfig) -> Result<UdpSocket> {
-    if config.interface_.is_empty() {
-        return udp_socket_simple(config).await;
-    }
-
-    let mut interface = config.interface_;
-    interface.try_push(char::default()).ok(); // add terminating null
-
-    let sock = socket2::Socket::new(
-        socket2::Domain::for_address(config.nameserver_),
-        socket2::Type::DGRAM.nonblocking().cloexec(),
-        Some(socket2::Protocol::UDP)
-    )?;
-
-    sock.bind_device(Some(interface.as_bytes()))?;
-
-    let sockaddr = socket2::SockAddr::from(config.bind_addr_);
-    sock.bind(&sockaddr)?;
-
-    let sockaddr = socket2::SockAddr::from(config.nameserver_);
-    sock.connect(&sockaddr)?;
-
-    let std_sock = unsafe { std::net::UdpSocket::from_raw_fd(sock.into_raw_fd()) };
-
-    Ok(UdpSocket::from_std(std_sock)?)
-}
-
-#[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))]
-async fn tcp_socket2(config: &ClientConfig) -> Result<TcpStream> {
-    if config.interface_.is_empty() {
-        return tcp_socket_simple(config).await;
-    }
-
-    let mut interface = config.interface_;
-    interface.try_push(char::default()).ok(); // add terminating null
-
-    let sock = socket2::Socket::new(
-        socket2::Domain::for_address(config.nameserver_),
-        socket2::Type::STREAM.nonblocking().cloexec(),
-        Some(socket2::Protocol::TCP)
-    )?;
-
-    sock.bind_device(Some(interface.as_bytes()))?;
-    sock.set_tcp_nodelay(true)?;
-
-    let tcp_socket = unsafe { TcpSocket::from_raw_fd(sock.into_raw_fd()) };
-
-    Ok(tcp_socket.connect(config.nameserver_).await?)
-}
-
-{% endif %}
-
-#[inline(always)]
-async fn udp_socket_simple(config: &ClientConfig) -> Result<UdpSocket> {
-    let sock = UdpSocket::bind(config.bind_addr_).await?;
-    sock.connect(config.nameserver_).await?;
-    Ok(sock)
-}
-
-#[inline(always)]
-async fn tcp_socket_simple(config: &ClientConfig) -> Result<TcpStream> {
-    let sock = TcpStream::connect(config.nameserver_).await?;
-    sock.set_nodelay(true)?;
-    Ok(sock)
-}
-
-#[inline(always)]
-async fn udp_socket(config: &ClientConfig) -> Result<UdpSocket> {
-    {% if crate_name != "tokio" %}
-
-    udp_socket_simple(config).await
-
-    {% else %}
-
-    cfg_if::cfg_if!{
-        if #[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))] {
-            udp_socket2(config).await
-        }
-        else {
-            udp_socket_simple(config).await
-        }
-    }
-
-    {% endif %}
-}
-
-#[inline(always)]
-async fn tcp_socket(config: &ClientConfig) -> Result<TcpStream> {
-    {% if crate_name != "tokio" %}
-
-    tcp_socket_simple(config).await
-
-    {% else %}
-
-    cfg_if::cfg_if!{
-        if #[cfg(all(target_os = "linux", feature = "net-tokio", feature = "socket2"))] {
-            tcp_socket2(config).await
-        }
-        else {
-            tcp_socket_simple(config).await
-        }
-    }
-
-    {% endif %}
+    .into()
 }

--- a/templates/client.rs
+++ b/templates/client.rs
@@ -1,80 +1,95 @@
-use crate::{
-    clients::{
-        {{ crate_module_name }}::ClientImpl,
-        config::ClientConfig,
-    },
-    records::{data::RData, Class, RecordSet, Type},
-    Result
-};
+use zyn::TokenStream;
 
-{% if async == "true" -%}
-{% set as = "async" %}
-{% set aw = ".await" %}
-/// Asynchronous client for the [`{{ crate_name }}`] async runtime.
-///
-/// [`{{ crate_name }}`]: https://docs.rs/{{ crate_name }}
-{% else -%}
-{% set as = "" %}
-{% set aw = "" %}
-/// Synchronous client implemented with [`std::net`].
-///
-/// [`std::net`]: https://doc.rust-lang.org/std/net
-{% endif -%}
-pub struct Client {
-    internal: ClientImpl,
-}
+pub fn render(crate_name: &str, is_async: bool) -> TokenStream {
+    let module = zyn::format_ident!("{}", super::dashes_to_underscores(crate_name));
+    let struct_doc_lines: Vec<String> = if is_async {
+        vec![
+            format!(
+                " Asynchronous client for the [`{}`] async runtime.",
+                crate_name
+            ),
+            String::new(),
+            format!(" [`{0}`]: https://docs.rs/{0}", crate_name),
+        ]
+    } else {
+        vec![
+            " Synchronous client implemented with [`std::net`].".into(),
+            String::new(),
+            " [`std::net`]: https://doc.rust-lang.org/std/net".into(),
+        ]
+    };
 
-impl Client {
-    /// Creates a new instance of [`Client`] with specified configuration.
-    #[inline(always)]
-    pub {{ as }} fn new(conf: ClientConfig) -> Result<Self> {
-        conf.check()?;
-        Ok(Self {
-            internal: ClientImpl::new(conf){{ aw }}?,
-        })
+    zyn::zyn! {
+        use crate::{
+            clients::{
+                {{ module }}::ClientImpl,
+                config::ClientConfig,
+            },
+            records::{data::RData, Class, RecordSet, Type},
+            Result
+        };
+
+        @for (line in struct_doc_lines.iter()) {
+            #[doc = {{ line }}]
+        }
+        pub struct Client {
+            internal: ClientImpl,
+        }
+
+        impl Client {
+            /// Creates a new instance of [`Client`] with specified configuration.
+            #[inline(always)]
+            pub @if (is_async) { async } fn new(conf: ClientConfig) -> Result<Self> {
+                conf.check()?;
+                Ok(Self {
+                    internal: ClientImpl::new(conf) @if (is_async) { .await } ?,
+                })
+            }
+
+            /// Returns the client configuration.
+            #[inline(always)]
+            pub fn config(&self) -> &ClientConfig {
+                self.internal.config()
+            }
+
+            /// Issues a DNS query and writes the response into caller-owned buffer.
+            ///
+            /// This method gives the control over buffer management to the caller.
+            /// The response message is written into `buf` and its length is returned in the result.
+            ///
+            /// See the [`message::reader`] module for ways to parse the received response.
+            ///
+            /// This method doesn't allocate.
+            ///
+            /// # Buffer size and EDNS
+            ///
+            /// The minimum size of `buf` is 512 bytes.
+            /// When EDNS is enabled, the UDP payload size sent in the `OPT` record is the minimum between
+            /// `udp_payload_size` configured in [`ClientConfig::edns`] and the size of `buf`.
+            ///
+            /// [`message::reader`]: crate::message::reader
+            #[inline(always)]
+            pub @if (is_async) { async } fn query_raw(&mut self, qname: &str, qtype: Type, qclass: Class, buf: &mut [u8]) -> Result<usize> {
+                self.internal.query_raw(qname, qtype, qclass, buf) @if (is_async) { .await }
+            }
+
+            /// Issues a DNS query and returns the resulting [`RecordSet`].
+            ///
+            /// Usually the resulting record set will belong to the domain name specified in `qname`.
+            /// However, if `qname` has a [`CNAME`] record, the record set will belong to `qname`'s
+            /// canonical name. See [`RecordSet::from_msg`] for *CNAME flattening* description.
+            ///
+            /// This method allows data-type queries only.
+            /// For meta-queries (e.g. [`Type::ANY`]) use [`query_raw`].
+            ///
+            /// This method allocates.
+            ///
+            /// [`CNAME`]: crate::records::data::Cname
+            /// [`query_raw`]: Self::query_raw
+            pub @if (is_async) { async } fn query_rrset<D: RData>(&mut self, qname: &str, qclass: Class) -> Result<RecordSet<D>> {
+                self.internal.query_rrset(qname, qclass) @if (is_async) { .await }
+            }
+        }
     }
-
-    /// Returns the client configuration.
-    #[inline(always)]
-    pub fn config(&self) -> &ClientConfig {
-        self.internal.config()
-    }
-
-    /// Issues a DNS query and writes the response into caller-owned buffer.
-    ///
-    /// This method gives the control over buffer management to the caller.
-    /// The response message is written into `buf` and its length is returned in the result.
-    ///
-    /// See the [`message::reader`] module for ways to parse the received response.
-    ///
-    /// This method doesn't allocate.
-    ///
-    /// # Buffer size and EDNS
-    ///
-    /// The minimum size of `buf` is 512 bytes.
-    /// When EDNS is enabled, the UDP payload size sent in the `OPT` record is the minimum between
-    /// `udp_payload_size` configured in [`ClientConfig::edns`] and the size of `buf`.
-    ///
-    /// [`message::reader`]: crate::message::reader
-    #[inline(always)]
-    pub {{ as }} fn query_raw(&mut self, qname: &str, qtype: Type, qclass: Class, buf: &mut [u8]) -> Result<usize> {
-        self.internal.query_raw(qname, qtype, qclass, buf){{ aw }}
-    }
-
-    /// Issues a DNS query and returns the resulting [`RecordSet`].
-    ///
-    /// Usually the resulting record set will belong to the domain name specified in `qname`.
-    /// However, if `qname` has a [`CNAME`] record, the record set will belong to `qname`'s
-    /// canonical name. See [`RecordSet::from_msg`] for *CNAME flattening* description.
-    ///
-    /// This method allows data-type queries only.
-    /// For meta-queries (e.g. [`Type::ANY`]) use [`query_raw`].
-    ///
-    /// This method allocates.
-    ///
-    /// [`CNAME`]: crate::records::data::Cname
-    /// [`query_raw`]: Self::query_raw
-    pub {{ as }} fn query_rrset<D: RData>(&mut self, qname: &str, qclass: Class) -> Result<RecordSet<D>> {
-        self.internal.query_rrset(qname, qclass){{ aw }}
-    }
+    .into()
 }


### PR DESCRIPTION
Now the template is written in Rust, more editor friendly.

Drop usage for rustfmt in favor of 'prettyplease'.
